### PR TITLE
Take into account color alpha, add option for extending the shield out by normals

### DIFF
--- a/shield_with_impacts.gdshader
+++ b/shield_with_impacts.gdshader
@@ -21,7 +21,6 @@ group_uniforms impact_parameters;
  */
 const int impacts_tracked = 16;
 
-// information about impact locations (xyz) and their age (w)
 /**
  * List of impact locations (xyz) and their age (w).
  * Age must be updated outside of the shader and passed in each frame.
@@ -45,7 +44,7 @@ varying vec3 local_pos;
 void vertex() {
 	// Extend the vertex position along its normal
 	VERTEX += NORMAL * extend_distance;
-	local_pos = VERTEX; // Store the updated position in local space
+	local_pos = VERTEX;
 }
 
 /**

--- a/shield_with_impacts.gdshader
+++ b/shield_with_impacts.gdshader
@@ -52,37 +52,37 @@ void vertex() {
  * Remap  a number from one range to another.
  */
 float remap(float num, float a1, float a2, float b1, float b2) {
-    return b1 + (num - a1) * (b2 - b1) / (a2 - a1);
+	return b1 + (num - a1) * (b2 - b1) / (a2 - a1);
 }
 
 void fragment() {
-    float wave_intensity = 0.0;
-    for (int i = 0; i < impacts_tracked; i++) {
-        // as impact age goes from 1 to 0, inv_time goes from 0 to 1
-        float inv_time = remap(pow(impact_points[i].w, impact_falloff_sharpness), 1, 0, 0.01, 0.99);
+	float wave_intensity = 0.0;
+	for (int i = 0; i < impacts_tracked; i++) {
+		// as impact age goes from 1 to 0, inv_time goes from 0 to 1
+		float inv_time = remap(pow(impact_points[i].w, impact_falloff_sharpness), 1, 0, 0.01, 0.99);
 
-        // we use inv_time here to make the wave expand over time rather than contract
-        float distance_to_impact = distance(local_pos, impact_points[i].xyz) / (inv_time * impact_size);
+		// we use inv_time here to make the wave expand over time rather than contract
+		float distance_to_impact = distance(local_pos, impact_points[i].xyz) / (inv_time * impact_size);
 
 		// default linear gradient
 		//float wave_shape = max(0, 1.0 - distance_to_impact);
-		
+
 		// sine donut with sharpening
 		//float sharpness = 1.0;
 		//float wave_shape = pow(sin(clamp(distance_to_impact / impact_size, 0, PI)), sharpness);
-		
+
 		// sawtooth donut with sharpening
-        float sharpness = 5.0;
-        float wave_shape = pow(fract(max(0, 1.0 - distance_to_impact) * -1.0), sharpness);
+		float sharpness = 5.0;
+		float wave_shape = pow(fract(max(0, 1.0 - distance_to_impact) * -1.0), sharpness);
 
-        // use impact age to make the wave fade over time
-        wave_intensity += wave_shape * pow(impact_points[i].w, impact_falloff_sharpness);
-    }
+		// use impact age to make the wave fade over time
+		wave_intensity += wave_shape * pow(impact_points[i].w, impact_falloff_sharpness);
+	}
 
-    float fresnel = pow(-dot(VIEW, NORMAL) + 1.0, fresnel_sharpness);
+	float fresnel = pow(-dot(VIEW, NORMAL) + 1.0, fresnel_sharpness);
 
-    ALBEDO.rgb = color.rgb;
+	ALBEDO.rgb = color.rgb;
 
-    // clamp the wave intensity so overlapping waves and fresnel edge dont have an intensity > 1
-    ALPHA = clamp(wave_intensity + fresnel, 0.0, 1.0) * color.a;
+	// clamp the wave intensity so overlapping waves and fresnel edge dont have an intensity > 1
+	ALPHA = clamp(wave_intensity + fresnel, 0.0, 1.0) * color.a;
 }

--- a/shield_with_impacts.gdshader
+++ b/shield_with_impacts.gdshader
@@ -43,9 +43,9 @@ uniform float impact_falloff_sharpness = 1.0;
 varying vec3 local_pos;
 
 void vertex() {
-    // Extend the vertex position along its normal
-    VERTEX += NORMAL * extend_distance;
-    local_pos = VERTEX; // Store the updated position in local space
+	// Extend the vertex position along its normal
+	VERTEX += NORMAL * extend_distance;
+	local_pos = VERTEX; // Store the updated position in local space
 }
 
 /**

--- a/shield_with_impacts.gdshader
+++ b/shield_with_impacts.gdshader
@@ -1,42 +1,69 @@
 shader_type spatial;
 
-render_mode unshaded;
+render_mode unshaded, cull_disabled;
 
 group_uniforms shield_parameters;
-uniform vec4 color : source_color;
+
+/** Color to use when rendering the shield */
+uniform vec4 color: source_color;
+
+/** How sharp the shield's outline is */
 uniform float fresnel_sharpness = 1.0;
 
+/** Distance to extend the shield out from each vertex */
+uniform float extend_distance = 0.0;
+
 group_uniforms impact_parameters;
-// this defines how many simultaneous impacts the shader will track
+
+/**
+ * How many impacts can be tracked by the shader.
+ * This should match the length of `impact_points` array that is passed in.
+ */
 const int impacts_tracked = 16;
+
 // information about impact locations (xyz) and their age (w)
+/**
+ * List of impact locations (xyz) and their age (w).
+ * Age must be updated outside of the shader and passed in each frame.
+ */
 uniform vec4 impact_points[impacts_tracked];
-// determines the size of the impacts
-// note that you could pass in an array here as well to determine impact size on a per-impact basis
-uniform float impact_size;
-// determines how sharply to curve the impacts expansion and fading
+
+/**
+ * Size of the impacts.
+ * This is used to determine how far the impact wave will expand.
+ *
+ * Possible improvement: switch this to an array to change the size of each impact.
+ */
+uniform float impact_size = 0.25;
+
+/** How sharply the impact wave will expand and fade */
 uniform float impact_falloff_sharpness = 1.0;
 
-// used to get the fragment position in object space without doing view matrix math
+/** Position of the vertex in local space */
 varying vec3 local_pos;
 
 void vertex() {
-	local_pos = VERTEX;
+    // Extend the vertex position along its normal
+    VERTEX += NORMAL * extend_distance;
+    local_pos = VERTEX; // Store the updated position in local space
 }
 
+/**
+ * Remap  a number from one range to another.
+ */
 float remap(float num, float a1, float a2, float b1, float b2) {
-	return b1 + (num - a1) * (b2 - b1) / (a2 - a1);
+    return b1 + (num - a1) * (b2 - b1) / (a2 - a1);
 }
 
 void fragment() {
-	float wave_intensity = 0.0;
-	for (int i = 0; i < impacts_tracked; i ++) {
-		// as impact_points[i].w goes from 1 to 0, inv_time goes from 0 to 1
-		float inv_time = remap(pow(impact_points[i].w, impact_falloff_sharpness), 1, 0, 0.01, 0.99);
-		
-		// we use inv_time here to make the wave expand over time rather than contract
-		float distance_to_impact = distance(local_pos, impact_points[i].xyz) / (inv_time * impact_size);
-		
+    float wave_intensity = 0.0;
+    for (int i = 0; i < impacts_tracked; i++) {
+        // as impact age goes from 1 to 0, inv_time goes from 0 to 1
+        float inv_time = remap(pow(impact_points[i].w, impact_falloff_sharpness), 1, 0, 0.01, 0.99);
+
+        // we use inv_time here to make the wave expand over time rather than contract
+        float distance_to_impact = distance(local_pos, impact_points[i].xyz) / (inv_time * impact_size);
+
 		// default linear gradient
 		//float wave_shape = max(0, 1.0 - distance_to_impact);
 		
@@ -45,16 +72,17 @@ void fragment() {
 		//float wave_shape = pow(sin(clamp(distance_to_impact / impact_size, 0, PI)), sharpness);
 		
 		// sawtooth donut with sharpening
-		float sharpness = 5.0;
-		float wave_shape = pow(fract(max(0, 1.0 - distance_to_impact) * -1.0), sharpness);
-		
-		// we use impact_points[i].w here to make the wave fade over time
-		wave_intensity += wave_shape * pow(impact_points[i].w, impact_falloff_sharpness);
-	}
-	
-	float fresnel = pow(-dot(VIEW, NORMAL) + 1.0, fresnel_sharpness);
-	
-	ALBEDO.rgb = color.rgb;
-	// clamp the wave intensity so overlapping waves and fresnel edge dont have an intensity > 1
-	ALPHA = clamp(wave_intensity + fresnel, 0, 1);
+        float sharpness = 5.0;
+        float wave_shape = pow(fract(max(0, 1.0 - distance_to_impact) * -1.0), sharpness);
+
+        // use impact age to make the wave fade over time
+        wave_intensity += wave_shape * pow(impact_points[i].w, impact_falloff_sharpness);
+    }
+
+    float fresnel = pow(-dot(VIEW, NORMAL) + 1.0, fresnel_sharpness);
+
+    ALBEDO.rgb = color.rgb;
+
+    // clamp the wave intensity so overlapping waves and fresnel edge dont have an intensity > 1
+    ALPHA = clamp(wave_intensity + fresnel, 0.0, 1.0) * color.a;
 }


### PR DESCRIPTION
This makes it so that the shield can be a sort of "skin" over another mesh by giving it 

Here, I'm rendering Suzanne with the shield shader as the "next pass": 

<img width="465" alt="Screenshot 2025-01-04 at 2 48 10 PM" src="https://github.com/user-attachments/assets/90249a93-2957-4a90-a49d-26163d7611b8" />

https://github.com/user-attachments/assets/3c700ec3-c052-42bb-976d-9431d9364e53

(I did have to change the script to set the material on the "next pass" shader, but I didn't include those changes in this PR)

I also changed the final color to take into account the alpha of the input color, so that you can have the shield itself fade in/out.